### PR TITLE
Fix missing cmake install headers.

### DIFF
--- a/tcp_pubsub/CMakeLists.txt
+++ b/tcp_pubsub/CMakeLists.txt
@@ -60,6 +60,11 @@ generate_export_header(${PROJECT_NAME}
   BASE_NAME TCP_PUBSUB
 )
 
+install(FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/tcp_pubsub_version.h
+            ${CMAKE_CURRENT_BINARY_DIR}/tcp_pubsub_export.h
+        DESTINATION include/tcp_pubsub)
+
 add_library (tcp_pubsub::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME}


### PR DESCRIPTION
Cmake did not install the headers tcp_pubsub_version.h and tcp_pubsub_export.h.
When trying to call this library to build another project, the missing headers produce an error.