### PR TITLE
Update file to latest from github.

### DIFF
--- a/tcp_pubsub/src/portable_endian.h
+++ b/tcp_pubsub/src/portable_endian.h
@@ -1,5 +1,5 @@
 // This file has been taken from:
-// https://gist.github.com/PkmX/63dd23f28ba885be53a5#file-portable_endian-h
+// https://gist.github.com/panzi/6856583#file-portable_endian-h
 //
 // "License": Public Domain
 // I, Mathias Panzenböck, place this file hereby into the public domain. Use it at your own risk for whatever you like.
@@ -28,12 +28,12 @@
 #	define htole16(x) OSSwapHostToLittleInt16(x)
 #	define be16toh(x) OSSwapBigToHostInt16(x)
 #	define le16toh(x) OSSwapLittleToHostInt16(x)
-
+ 
 #	define htobe32(x) OSSwapHostToBigInt32(x)
 #	define htole32(x) OSSwapHostToLittleInt32(x)
 #	define be32toh(x) OSSwapBigToHostInt32(x)
 #	define le32toh(x) OSSwapLittleToHostInt32(x)
-
+ 
 #	define htobe64(x) OSSwapHostToBigInt64(x)
 #	define htole64(x) OSSwapHostToLittleInt64(x)
 #	define be64toh(x) OSSwapBigToHostInt64(x)
@@ -46,7 +46,12 @@
 
 #elif defined(__OpenBSD__)
 
-#	include <sys/endian.h>
+#	include <endian.h>
+
+#	define __BYTE_ORDER    BYTE_ORDER
+#	define __BIG_ENDIAN    BIG_ENDIAN
+#	define __LITTLE_ENDIAN LITTLE_ENDIAN
+#	define __PDP_ENDIAN    PDP_ENDIAN
 
 #elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
 
@@ -63,46 +68,45 @@
 
 #elif defined(__WINDOWS__)
 
-#	include <windows.h>
+#	include <winsock2.h>
+#	ifdef __GNUC__
+#		include <sys/param.h>
+#	endif
 
 #	if BYTE_ORDER == LITTLE_ENDIAN
 
-#               if defined(_MSC_VER)
-#                       include <stdlib.h>
-#			define htobe16(x) _byteswap_ushort(x)
-#			define htole16(x) (x)
-#			define be16toh(x) _byteswap_ushort(x)
-#			define le16toh(x) (x)
+#		define htobe16(x) htons(x)
+#		define htole16(x) (x)
+#		define be16toh(x) ntohs(x)
+#		define le16toh(x) (x)
+ 
+#		define htobe32(x) htonl(x)
+#		define htole32(x) (x)
+#		define be32toh(x) ntohl(x)
+#		define le32toh(x) (x)
+ 
+#		define htobe64(x) htonll(x)
+#		define htole64(x) (x)
+#		define be64toh(x) ntohll(x)
+#		define le64toh(x) (x)
 
-#			define htobe32(x) _byteswap_ulong(x)
-#			define htole32(x) (x)
-#			define be32toh(x) _byteswap_ulong(x)
-#			define le32toh(x) (x)
+#	elif BYTE_ORDER == BIG_ENDIAN
 
-#			define htobe64(x) _byteswap_uint64(x)
-#			define htole64(x) (x)
-#			define be64toh(x) _byteswap_uint64(x)
-#			define le64toh(x) (x)
-
-#               elif defined(__GNUC__) || defined(__clang__)
-
-#			define htobe16(x) __builtin_bswap16(x)
-#			define htole16(x) (x)
-#			define be16toh(x) __builtin_bswap16(x)
-#			define le16toh(x) (x)
-
-#			define htobe32(x) __builtin_bswap32(x)
-#			define htole32(x) (x)
-#			define be32toh(x) __builtin_bswap32(x)
-#			define le32toh(x) (x)
-
-#			define htobe64(x) __builtin_bswap64(x)
-#			define htole64(x) (x)
-#			define be64toh(x) __builtin_bswap64(x)
-#			define le64toh(x) (x)
-#               else
-#                       error platform not supported
-#               endif
+		/* that would be xbox 360 */
+#		define htobe16(x) (x)
+#		define htole16(x) __builtin_bswap16(x)
+#		define be16toh(x) (x)
+#		define le16toh(x) __builtin_bswap16(x)
+ 
+#		define htobe32(x) (x)
+#		define htole32(x) __builtin_bswap32(x)
+#		define be32toh(x) (x)
+#		define le32toh(x) __builtin_bswap32(x)
+ 
+#		define htobe64(x) (x)
+#		define htole64(x) __builtin_bswap64(x)
+#		define be64toh(x) (x)
+#		define le64toh(x) __builtin_bswap64(x)
 
 #	else
 
@@ -114,6 +118,51 @@
 #	define __BIG_ENDIAN    BIG_ENDIAN
 #	define __LITTLE_ENDIAN LITTLE_ENDIAN
 #	define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__QNXNTO__)
+
+#	include <gulliver.h>
+
+#	define __LITTLE_ENDIAN 1234
+#	define __BIG_ENDIAN    4321
+#	define __PDP_ENDIAN    3412
+
+#	if defined(__BIGENDIAN__)
+
+#		define __BYTE_ORDER __BIG_ENDIAN
+
+#		define htobe16(x) (x)
+#		define htobe32(x) (x)
+#		define htobe64(x) (x)
+
+#		define htole16(x) ENDIAN_SWAP16(x)
+#		define htole32(x) ENDIAN_SWAP32(x)
+#		define htole64(x) ENDIAN_SWAP64(x)
+
+#	elif defined(__LITTLEENDIAN__)
+
+#		define __BYTE_ORDER __LITTLE_ENDIAN
+
+#		define htole16(x) (x)
+#		define htole32(x) (x)
+#		define htole64(x) (x)
+
+#		define htobe16(x) ENDIAN_SWAP16(x)
+#		define htobe32(x) ENDIAN_SWAP32(x)
+#		define htobe64(x) ENDIAN_SWAP64(x)
+
+#	else
+
+#		error byte order not supported
+
+#	endif
+
+#	define be16toh(x) ENDIAN_BE16(x)
+#	define be32toh(x) ENDIAN_BE32(x)
+#	define be64toh(x) ENDIAN_BE64(x)
+#	define le16toh(x) ENDIAN_LE16(x)
+#	define le32toh(x) ENDIAN_LE32(x)
+#	define le64toh(x) ENDIAN_LE64(x)
 
 #else
 


### PR DESCRIPTION
This is the original from https://gist.github.com/panzi/6856583#file-portable_endian-h which had QNX support added.
The prior file was https://gist.github.com/panzi/6856583#file-portable_endian-h, which is a fork from a  prior version of the previous link.

However it differs in also the Windows implementation. We should see if we do it like this or merge in only the QNX changes.