### PR TITLE
GH Actions: Updated steps to latest versions

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules:  'true'
         fetch-depth: 0

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -35,7 +35,7 @@ jobs:
         fi
     
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules:  'true'
         fetch-depth: 0
@@ -61,7 +61,7 @@ jobs:
       working-directory: ${{ github.workspace }}/_build
 
     - name: Upload binaries
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: tcp-pubsub-${{ matrix.os }}-${{ env.package_postfix }}
         path: ${{github.workspace}}/_build/_package/*.deb

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -36,7 +36,7 @@ jobs:
         }
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules:  'true'
         fetch-depth: 0
@@ -72,7 +72,7 @@ jobs:
            cmake --build ${{github.workspace}}/_build --config Debug --target INSTALL
 
     - name: Upload binaries
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: tcp-pubsub-win64-${{ matrix.library_type }}
         path: ${{github.workspace}}/${{env.INSTALL_PREFIX}}


### PR DESCRIPTION
Updated checkout and upload-artifact steps to the latest version to get rid of the deprecated-nodejs warnings.