### PR TITLE
[cmake] Update supported policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...4.0)
 
 include(CMakeDependentOption)
 

--- a/samples/ecal_to_tcp/CMakeLists.txt
+++ b/samples/ecal_to_tcp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.5.1...4.0)
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(ecal_to_tcp)

--- a/samples/hello_world_publisher/CMakeLists.txt
+++ b/samples/hello_world_publisher/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.5.1...4.0)
 
 project(hello_world_publisher)
 

--- a/samples/hello_world_subscriber/CMakeLists.txt
+++ b/samples/hello_world_subscriber/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.5.1...4.0)
 
 project(hello_world_subscriber)
 

--- a/samples/integration_test/CMakeLists.txt
+++ b/samples/integration_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.5.1...4.0)
 
 project(integration_test)
 

--- a/samples/performance_publisher/CMakeLists.txt
+++ b/samples/performance_publisher/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.5.1...4.0)
 
 project(performance_publisher)
 

--- a/samples/performance_subscriber/CMakeLists.txt
+++ b/samples/performance_subscriber/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.5.1...4.0)
 
 project(performance_subscriber)
 

--- a/samples/tcp_to_ecal/CMakeLists.txt
+++ b/samples/tcp_to_ecal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.5.1...4.0)
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(tcp_to_ecal)

--- a/tcp_pubsub/CMakeLists.txt
+++ b/tcp_pubsub/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.5.1...4.0)
 
 include("${CMAKE_CURRENT_LIST_DIR}/version.cmake")
 project(tcp_pubsub VERSION ${TCP_PUBSUB_VERSION_MAJOR}.${TCP_PUBSUB_VERSION_MINOR}.${TCP_PUBSUB_VERSION_PATCH})

--- a/tests/tcp_pubsub_test/CMakeLists.txt
+++ b/tests/tcp_pubsub_test/CMakeLists.txt
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: MIT
 ################################################################################
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...4.0)
 
 project(tcp_pubsub_test)
 

--- a/thirdparty/recycle/build-recycle.cmake
+++ b/thirdparty/recycle/build-recycle.cmake
@@ -1,5 +1,4 @@
 add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/recycle" EXCLUDE_FROM_ALL)
-add_library(steinwurf::recycle ALIAS recycle)
 
 # Prepend asio-module/Findrecycle.cmake to the module path
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}/Module")


### PR DESCRIPTION
Updates the project to support all policy changes up to CMake 4.0. The only notable change was removing the alias creation for recycle as the submodule was already creating it and CMP0107 disallows recreation of an alias target. Everything else was simple CMake so no problems.